### PR TITLE
ARGO-1327 Update probe data without creating new version

### DIFF
--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -264,14 +264,7 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
                 newdata = data
                 newdata[0]['fields'] = newfield
                 Version.objects.filter(pk=version[0].object_id).update(serialized_data=json.dumps(newdata))
-                Probe.objects.filter(pk=pk).update(name=form.cleaned_data['name'])
-                Probe.objects.filter(pk=pk).update(version=form.cleaned_data['version'])
-                Probe.objects.filter(pk=pk).update(description=form.cleaned_data['description'])
-                Probe.objects.filter(pk=pk).update(comment=form.cleaned_data['comment'])
-                Probe.objects.filter(pk=pk).update(repository=form.cleaned_data['repository'])
-                Probe.objects.filter(pk=pk).update(docurl=form.cleaned_data['docurl'])
-                Probe.objects.filter(pk=pk).update(group=obj.group)
-                Probe.objects.filter(pk=pk).update(user=obj.user)
+                Probe.objects.filter(pk=pk).update(**newdata[0]['fields'])
         else:
             raise PermissionDenied()
 

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -134,18 +134,20 @@ class ProbeForm(ModelForm):
     user = CharField(help_text='User that added the probe', max_length=64, required=False)
     datetime = CharField(help_text='Time when probe is added', max_length=64, required=False)
 
-    def clean_version(self):
-        ver = self.cleaned_data['version']
-        name = self.cleaned_data['name']
+    def clean(self):
+        cleaned_data = super(ProbeForm, self).clean()
+        new_ver = cleaned_data['new_version']
+        ver = cleaned_data['version']
+        name = cleaned_data['name']
 
         try:
             probe = Probe.objects.get(name=name)
-            if probe.version == ver:
+            if probe.version == ver and new_ver:
                 raise ValidationError("Version number should be raised")
         except Probe.DoesNotExist:
             pass
 
-        return ver
+        return cleaned_data
 
 class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
     """

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -265,7 +265,7 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
                 newdata = data
                 newdata[0]['fields'] = new_serialized_field
                 Version.objects.filter(pk=pk0).update(serialized_data=json.dumps(newdata))
-                Probe.objects.filter(pk=pk).update(**newdata[0]['fields'])
+                Probe.objects.filter(pk=pk).update(**new_serialized_field)
         else:
             raise PermissionDenied()
 

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -233,19 +233,22 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         sh = SharedInfo()
 
-        if obj and sh.getgroup():
-            obj.group = sh.getgroup().name
-            sh.delgroup()
-        elif not obj and sh.getgroup():
-            obj.group = sh.getgroup()
-            sh.delgroup()
-        if request.user.has_perm('poem.groupown_probe') \
-                or request.user.is_superuser:
-            obj.user = request.user.username
-            obj.save()
-            return
+        if form.cleaned_data['new_version']:
+            if obj and sh.getgroup():
+                obj.group = sh.getgroup().name
+                sh.delgroup()
+            elif not obj and sh.getgroup():
+                obj.group = sh.getgroup()
+                sh.delgroup()
+            if request.user.has_perm('poem.groupown_probe') \
+                    or request.user.is_superuser:
+                obj.user = request.user.username
+                obj.save()
+                return
+            else:
+                raise PermissionDenied()
         else:
-            raise PermissionDenied()
+            pass
 
     def get_row_css(self, obj, index):
         if not obj.valid:

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -252,17 +252,18 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
                 pk = version[0].object_id
                 pk0 = version[0].id
                 data = json.loads(Version.objects.get(pk=pk0).serialized_data)
-                newfield = dict()
-                newfield['name'] = form.cleaned_data['name']
-                newfield['version'] = form.cleaned_data['version']
-                newfield['description'] = form.cleaned_data['description']
-                newfield['comment'] = form.cleaned_data['comment']
-                newfield['repository'] = form.cleaned_data['repository']
-                newfield['docurl'] = form.cleaned_data['docurl']
-                newfield['group'] = obj.group
-                newfield['user'] = obj.user
+                new_serialized_field = {
+                    'name': form.cleaned_data['name'],
+                    'version': form.cleaned_data['version'],
+                    'description': form.cleaned_data['description'],
+                    'comment': form.cleaned_data['comment'],
+                    'repository': form.cleaned_data['repository'],
+                    'docurl': form.cleaned_data['docurl'],
+                    'group': obj.group,
+                    'user': obj.user
+                }
                 newdata = data
-                newdata[0]['fields'] = newfield
+                newdata[0]['fields'] = new_serialized_field
                 Version.objects.filter(pk=version[0].object_id).update(serialized_data=json.dumps(newdata))
                 Probe.objects.filter(pk=pk).update(**newdata[0]['fields'])
         else:

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -233,7 +233,7 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         sh = SharedInfo()
 
-        if form.cleaned_data['new_version']:
+        if form.cleaned_data['new_version'] and change == True or change == False:
             if obj and sh.getgroup():
                 obj.group = sh.getgroup().name
                 sh.delgroup()

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -264,7 +264,7 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
                 }
                 newdata = data
                 newdata[0]['fields'] = new_serialized_field
-                Version.objects.filter(pk=version[0].object_id).update(serialized_data=json.dumps(newdata))
+                Version.objects.filter(pk=pk0).update(serialized_data=json.dumps(newdata))
                 Probe.objects.filter(pk=pk).update(**newdata[0]['fields'])
         else:
             raise PermissionDenied()

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from django.forms import ModelForm, CharField, Textarea, ValidationError, ModelChoiceField
+from django.forms import ModelForm, CharField, Textarea, ValidationError, ModelChoiceField, BooleanField
 from django.forms.widgets import TextInput, Select
 from django.contrib import admin
 from django.contrib.auth.models import Permission
@@ -106,6 +106,8 @@ class ProbeForm(ModelForm):
     Connects profile attributes to autocomplete widget (:py:mod:`poem.widgets`). Also
     adds media and does basic sanity checking for input.
     """
+    new_version = BooleanField(help_text='Is probe version the same', required=False, initial=True)
+
     name = CharField(help_text='Name of this probe.',
                      max_length=100,
                      widget=TextInput(attrs={'maxlength': 100, 'size': 45}),
@@ -216,7 +218,7 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
             else:
                 self._groupown_turn(request.user, 'del')
         if obj:
-            self.fieldsets = ((None, {'classes': ['infoone'], 'fields': (('name', 'version',), 'datetime', 'user', )}),
+            self.fieldsets = ((None, {'classes': ['infoone'], 'fields': (('name', 'version', 'new_version',), 'datetime', 'user', )}),
                               (None, {'classes': ['infotwo'], 'fields': ('repository', 'docurl', 'description','comment',)}),)
             self.readonly_fields = ('user', 'datetime',)
         else:

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -262,9 +262,8 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
                     'group': obj.group,
                     'user': obj.user
                 }
-                newdata = data
-                newdata[0]['fields'] = new_serialized_field
-                Version.objects.filter(pk=pk0).update(serialized_data=json.dumps(newdata))
+                data[0]['fields'] = new_serialized_field
+                Version.objects.filter(pk=pk0).update(serialized_data=json.dumps(data))
                 Probe.objects.filter(pk=pk).update(**new_serialized_field)
         else:
             raise PermissionDenied()

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -106,7 +106,7 @@ class ProbeForm(ModelForm):
     Connects profile attributes to autocomplete widget (:py:mod:`poem.widgets`). Also
     adds media and does basic sanity checking for input.
     """
-    new_version = BooleanField(help_text='Is probe version the same', required=False, initial=True)
+    new_version = BooleanField(help_text='Create version for changes', required=False, initial=True)
 
     name = CharField(help_text='Name of this probe.',
                      max_length=100,

--- a/poem/Poem/poem/admin_interface/siteprobes.py
+++ b/poem/Poem/poem/admin_interface/siteprobes.py
@@ -244,10 +244,10 @@ class ProbeAdmin(CompareVersionAdmin, admin.ModelAdmin):
         if request.user.has_perm('poem.groupown_probe') \
                 or request.user.is_superuser:
             obj.user = request.user.username
-            if form.cleaned_data['new_version'] and change == True or change == False:
+            if form.cleaned_data['new_version'] and change or not change:
                 obj.save()
                 return
-            elif not form.cleaned_data['new_version'] and change == True:
+            elif not form.cleaned_data['new_version'] and change:
                 version = Version.objects.get_for_object(obj)
                 pk = version[0].object_id
                 pk0 = version[0].id

--- a/poem/media/css/siteprobes.css
+++ b/poem/media/css/siteprobes.css
@@ -14,6 +14,12 @@ fieldset.infoone input#id_new_version {
     width: 30px;
 }
 
+fieldset.infoone > div > div.field-new_version > div.help {
+    margin-top: 2px;
+    padding-left: 0px;
+    margin-left: 0px;
+}
+
 fieldset.infoone div.field-box.field-datetime {
     width: 220px;
 }

--- a/poem/media/css/siteprobes.css
+++ b/poem/media/css/siteprobes.css
@@ -10,6 +10,10 @@ fieldset.infoone input#id_version {
     width: 50px;
 }
 
+fieldset.infoone input#id_new_version {
+    width: 50px;
+}
+
 fieldset.infoone div.field-box.field-datetime {
     width: 220px;
 }

--- a/poem/media/css/siteprobes.css
+++ b/poem/media/css/siteprobes.css
@@ -11,7 +11,7 @@ fieldset.infoone input#id_version {
 }
 
 fieldset.infoone input#id_new_version {
-    width: 50px;
+    width: 30px;
 }
 
 fieldset.infoone div.field-box.field-datetime {


### PR DESCRIPTION
Probe data can now be updated without the need to change the probe version. The checkerbox was added to choose if the version should or should not be changed.