### PR TITLE
ARGO-1688 Migrations are not registered as applied

### DIFF
--- a/bin/poem-db
+++ b/bin/poem-db
@@ -61,6 +61,9 @@ do
         a)
             su -m -s /bin/sh $RUNASUSER -c \
             "export DJANGO_SETTINGS_MODULE=Poem.settings && \
+            python $SITEPACK/Poem/manage.py migrate_schemas --shared"
+            su -m -s /bin/sh $RUNASUSER -c \
+            "export DJANGO_SETTINGS_MODULE=Poem.settings && \
             python $SITEPACK/Poem/manage.py migrate_schemas poem --tenant"
             ;;
         l)


### PR DESCRIPTION
The bug is fixed by running migrations on both tenant schemas and public schema.